### PR TITLE
no op for publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,7 @@ Soroban-specific components of [CVLR](https://github.com/Certora/cvlr) (Certora 
 
 ## Overview
 
-This workspace provides Soroban-related utilities for writing specs for Certora's. Sunbeam verifier. It includes:
-
-- nondeterministic constructors for common Soroban values
-- logging adapters for Soroban SDK types
-- verification helpers for authorization-related reasoning
-- proc-macros for rules, mock clients, and Soroban compatibility shims
-- helper macros for swapping native implementations with summarized verification behavior
-
-## Workspace Crates
-
-This repository contains three crates:
-
-### `cvlr-soroban`
-
-Core Soroban support for verification-oriented builds, including:
-
-- nondeterministic `Address`, `Map`, `String`, `Vec`, `Symbol`, `Bytes`, and `BytesN<32>` constructors
-- logging wrappers for `Address`, `Symbol`, `Bytes`, and `BytesN<32>` through `cvlr-log`
-- helper APIs such as `is_auth` for reasoning about authorization in specs
-
-### `cvlr-soroban-derive`
-
-Proc-macros for Soroban verification workflows, including:
-
-- `#[rule]` and `declare_rule!` for rule registration
-- `#[cvlr_mock_client(...)]` for generating mock client implementations from traits
-- `#[contractevent]` and `#[topic]` compatibility shims for CVLR builds
-
-### `cvlr-soroban-macros`
-
-Macro helpers used to redirect code to summarized verification behavior, including:
-
-- `apply_summary!` for replacing function or method bodies under verification-specific configurations
+This repo provides Soroban-related utilities for writing specs for Certora's Sunbeam verifier.
 
 ## Getting Started
 
@@ -49,8 +17,6 @@ cvlr-soroban-derive = "0.4.0"
 cvlr-soroban-macros = "0.4.0"
 soroban-sdk = "25.1.1"
 ```
-
-Omit any crates that your project does not use.
 
 ## Using Unreleased Versions
 
@@ -98,7 +64,7 @@ MACROTEST=overwrite cargo test -p cvlr-soroban-derive --test test_contractevent 
 ## Documentation and Related Repositories
 
 - [CVLR](https://github.com/Certora/cvlr)
-- [Soroban verification documentation](https://docs.certora.com/en/latest/docs/sunbeam/index.html)
+- [Soroban verification documentation](https://docs.certora.com/en/latest/docs/sunbeam/index.html) for how to write specs and run Sunbeam
 - [Sunbeam tutorials](https://github.com/Certora/sunbeam-tutorials)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,5 +1,110 @@
 # CVLR for Soroban
 
-Soroban specific parts of the CVLR library.
+Soroban-specific components of [CVLR](https://github.com/Certora/cvlr) (Certora Verification Language for Rust), used for writing and verifying Soroban smart contracts with the Certora's Sunbeam verifier.
 
+## Overview
 
+This workspace provides Soroban-related utilities for writing specs for Certora's. Sunbeam verifier. It includes:
+
+- nondeterministic constructors for common Soroban values
+- logging adapters for Soroban SDK types
+- verification helpers for authorization-related reasoning
+- proc-macros for rules, mock clients, and Soroban compatibility shims
+- helper macros for swapping native implementations with summarized verification behavior
+
+## Workspace Crates
+
+This repository contains three crates:
+
+### `cvlr-soroban`
+
+Core Soroban support for verification-oriented builds, including:
+
+- nondeterministic `Address`, `Map`, `String`, `Vec`, `Symbol`, `Bytes`, and `BytesN<32>` constructors
+- logging wrappers for `Address`, `Symbol`, `Bytes`, and `BytesN<32>` through `cvlr-log`
+- helper APIs such as `is_auth` for reasoning about authorization in specs
+
+### `cvlr-soroban-derive`
+
+Proc-macros for Soroban verification workflows, including:
+
+- `#[rule]` and `declare_rule!` for rule registration
+- `#[cvlr_mock_client(...)]` for generating mock client implementations from traits
+- `#[contractevent]` and `#[topic]` compatibility shims for CVLR builds
+
+### `cvlr-soroban-macros`
+
+Macro helpers used to redirect code to summarized verification behavior, including:
+
+- `apply_summary!` for replacing function or method bodies under verification-specific configurations
+
+## Getting Started
+
+Add the crates you need to your `Cargo.toml`:
+
+```toml
+[dependencies]
+cvlr-soroban = "0.4.0"
+cvlr-soroban-derive = "0.4.0"
+cvlr-soroban-macros = "0.4.0"
+soroban-sdk = "25.1.1"
+```
+
+Omit any crates that your project does not use.
+
+## Using Unreleased Versions
+
+If you want to consume the latest unreleased version of a crate from this workspace, you can depend on it directly from GitHub instead of crates.io:
+
+```toml
+[dependencies]
+cvlr-soroban = { git = "https://github.com/Certora/cvlr-soroban", branch = "main" }
+cvlr-soroban-derive = { git = "https://github.com/Certora/cvlr-soroban", branch = "main" }
+cvlr-soroban-macros = { git = "https://github.com/Certora/cvlr-soroban", branch = "main" }
+```
+
+## Building and Testing
+
+Build the workspace:
+
+```bash
+cargo build --release
+```
+
+Run all tests:
+
+```bash
+cargo test
+```
+
+The proc-macro expansion tests in `cvlr-soroban-derive` use `macrotest` and `trybuild`. They require `cargo-expand`:
+
+```bash
+cargo install cargo-expand
+```
+
+Run the proc-macro test harness:
+
+```bash
+cargo test -p cvlr-soroban-derive --test test_contractevent
+```
+
+If you intentionally change macro expansion and want to refresh the snapshot files:
+
+```bash
+MACROTEST=overwrite cargo test -p cvlr-soroban-derive --test test_contractevent test_contractevent_macro_expansion
+```
+
+## Documentation and Related Repositories
+
+- [CVLR](https://github.com/Certora/cvlr)
+- [Soroban verification documentation](https://docs.certora.com/en/latest/docs/sunbeam/index.html)
+- [Sunbeam tutorials](https://github.com/Certora/sunbeam-tutorials)
+
+## License
+
+This project is licensed under the MIT License.
+
+## Release
+
+Current release: `0.4.0`

--- a/cvlr-soroban-derive/Cargo.toml
+++ b/cvlr-soroban-derive/Cargo.toml
@@ -25,3 +25,8 @@ quote = { workspace = true }
 syn = { workspace = true }
 proc-macro2 = { workspace = true }
 darling = { version = "0.20" }
+
+[dev-dependencies]
+macrotest = { workspace = true }
+trybuild = { workspace = true }
+soroban-sdk = { workspace = true }

--- a/cvlr-soroban-derive/src/lib.rs
+++ b/cvlr-soroban-derive/src/lib.rs
@@ -24,6 +24,9 @@ pub fn rule(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// as an unused field attribute.
 /// # Example
 /// ```
+/// use cvlr_soroban_derive::contractevent;
+/// use soroban_sdk::{Address, Symbol};
+///
 /// #[contractevent]
 /// #[derive(Clone, Debug, Eq, PartialEq)]
 /// pub struct RoleGranted {
@@ -54,7 +57,7 @@ pub fn contractevent(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         // stub out `publish`
         impl #gen_impl #ident #gen_types #gen_where {
-            pub fn publish(&self, _env: &Env) {}
+            pub fn publish(&self, _env: &soroban_sdk::Env) {}
         }
     }
     .into()

--- a/cvlr-soroban-derive/src/lib.rs
+++ b/cvlr-soroban-derive/src/lib.rs
@@ -51,16 +51,20 @@ pub fn contractevent(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    let vis = &output.vis;
     let ident = &output.ident;
-    let fields = &output.fields;
+    let generics = &output.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    // Return the struct without `#[topic]`
-    let expanded = quote::quote! {
-        #vis struct #ident #fields
-    };
+    quote::quote! {
+        #output
 
-    expanded.into()
+        // stub out `publish`
+        impl #impl_generics #ident #ty_generics #where_clause {
+            #[inline(always)]
+            pub fn publish<E>(&self, _env: &E) {}
+        }
+    }
+    .into()
 }
 
 /// A no-op attribute so `#[topic]` doesn't cause errors outside of

--- a/cvlr-soroban-derive/src/lib.rs
+++ b/cvlr-soroban-derive/src/lib.rs
@@ -47,15 +47,14 @@ pub fn contractevent(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let ident = &output.ident;
     let generics = &output.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (gen_impl, gen_types, gen_where) = generics.split_for_impl();
 
     quote::quote! {
         #output
 
         // stub out `publish`
-        impl #impl_generics #ident #ty_generics #where_clause {
-            #[inline(always)]
-            pub fn publish<E>(&self, _env: &E) {}
+        impl #gen_impl #ident #gen_types #gen_where {
+            pub fn publish(&self, _env: &Env) {}
         }
     }
     .into()

--- a/cvlr-soroban-derive/src/lib.rs
+++ b/cvlr-soroban-derive/src/lib.rs
@@ -36,18 +36,12 @@ pub fn rule(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn contractevent(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(item as syn::ItemStruct);
-    let mut output = input.clone();
+    let mut output = syn::parse_macro_input!(item as syn::ItemStruct);
 
     // Remove #[topic] attributes from fields
     if let syn::Fields::Named(ref mut fields) = output.fields {
         for field in &mut fields.named {
-            field.attrs = field
-                .attrs
-                .iter()
-                .filter(|a| !a.path().is_ident("topic"))
-                .cloned()
-                .collect::<Vec<syn::Attribute>>();
+            field.attrs.retain(|a| !a.path().is_ident("topic"));
         }
     }
 

--- a/cvlr-soroban-derive/tests/expand/basic.expanded.rs
+++ b/cvlr-soroban-derive/tests/expand/basic.expanded.rs
@@ -1,0 +1,67 @@
+#![allow(dead_code)]
+use cvlr_soroban_derive::contractevent;
+pub struct RoleGranted {
+    pub role: u32,
+    pub account: u64,
+    pub caller: bool,
+}
+#[automatically_derived]
+impl ::core::clone::Clone for RoleGranted {
+    #[inline]
+    fn clone(&self) -> RoleGranted {
+        RoleGranted {
+            role: ::core::clone::Clone::clone(&self.role),
+            account: ::core::clone::Clone::clone(&self.account),
+            caller: ::core::clone::Clone::clone(&self.caller),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for RoleGranted {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(
+            f,
+            "RoleGranted",
+            "role",
+            &self.role,
+            "account",
+            &self.account,
+            "caller",
+            &&self.caller,
+        )
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::Eq for RoleGranted {
+    #[inline]
+    #[doc(hidden)]
+    #[coverage(off)]
+    fn assert_receiver_is_total_eq(&self) -> () {
+        let _: ::core::cmp::AssertParamIsEq<u32>;
+        let _: ::core::cmp::AssertParamIsEq<u64>;
+        let _: ::core::cmp::AssertParamIsEq<bool>;
+    }
+}
+#[automatically_derived]
+impl ::core::marker::StructuralPartialEq for RoleGranted {}
+#[automatically_derived]
+impl ::core::cmp::PartialEq for RoleGranted {
+    #[inline]
+    fn eq(&self, other: &RoleGranted) -> bool {
+        self.role == other.role && self.account == other.account
+            && self.caller == other.caller
+    }
+}
+impl RoleGranted {
+    pub fn publish(&self, _env: &soroban_sdk::Env) {}
+}
+fn main() {
+    let env = soroban_sdk::Env::default();
+    let event = RoleGranted {
+        role: 7,
+        account: 42,
+        caller: true,
+    };
+    event.publish(&env);
+}

--- a/cvlr-soroban-derive/tests/expand/basic.rs
+++ b/cvlr-soroban-derive/tests/expand/basic.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use cvlr_soroban_derive::contractevent;
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleGranted {
+    #[topic]
+    pub role: u32,
+    #[topic]
+    pub account: u64,
+    pub caller: bool,
+}
+
+fn main() {
+    let env = soroban_sdk::Env::default();
+    let event = RoleGranted {
+        role: 7,
+        account: 42,
+        caller: true,
+    };
+
+    event.publish(&env);
+}

--- a/cvlr-soroban-derive/tests/expand/generics.expanded.rs
+++ b/cvlr-soroban-derive/tests/expand/generics.expanded.rs
@@ -1,0 +1,81 @@
+#![allow(dead_code)]
+use cvlr_soroban_derive::contractevent;
+pub struct GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    pub label: &'a str,
+    pub payload: T,
+}
+#[automatically_derived]
+impl<'a, T: ::core::clone::Clone> ::core::clone::Clone for GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    #[inline]
+    fn clone(&self) -> GenericEvent<'a, T> {
+        GenericEvent {
+            label: ::core::clone::Clone::clone(&self.label),
+            payload: ::core::clone::Clone::clone(&self.payload),
+        }
+    }
+}
+#[automatically_derived]
+impl<'a, T: ::core::fmt::Debug> ::core::fmt::Debug for GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "GenericEvent",
+            "label",
+            &self.label,
+            "payload",
+            &&self.payload,
+        )
+    }
+}
+#[automatically_derived]
+impl<'a, T: ::core::cmp::Eq> ::core::cmp::Eq for GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    #[inline]
+    #[doc(hidden)]
+    #[coverage(off)]
+    fn assert_receiver_is_total_eq(&self) -> () {
+        let _: ::core::cmp::AssertParamIsEq<&'a str>;
+        let _: ::core::cmp::AssertParamIsEq<T>;
+    }
+}
+#[automatically_derived]
+impl<'a, T> ::core::marker::StructuralPartialEq for GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{}
+#[automatically_derived]
+impl<'a, T: ::core::cmp::PartialEq> ::core::cmp::PartialEq for GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    #[inline]
+    fn eq(&self, other: &GenericEvent<'a, T>) -> bool {
+        self.label == other.label && self.payload == other.payload
+    }
+}
+impl<'a, T> GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    pub fn publish(&self, _env: &soroban_sdk::Env) {}
+}
+fn main() {
+    let env = soroban_sdk::Env::default();
+    let event = GenericEvent {
+        label: "alpha",
+        payload: 9_u32,
+    };
+    event.publish(&env);
+}

--- a/cvlr-soroban-derive/tests/expand/generics.rs
+++ b/cvlr-soroban-derive/tests/expand/generics.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use cvlr_soroban_derive::contractevent;
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GenericEvent<'a, T>
+where
+    T: Clone + Eq,
+{
+    #[topic]
+    pub label: &'a str,
+    pub payload: T,
+}
+
+fn main() {
+    let env = soroban_sdk::Env::default();
+    let event = GenericEvent {
+        label: "alpha",
+        payload: 9_u32,
+    };
+
+    event.publish(&env);
+}

--- a/cvlr-soroban-derive/tests/test_contractevent.rs
+++ b/cvlr-soroban-derive/tests/test_contractevent.rs
@@ -1,0 +1,11 @@
+#[test]
+fn test_contractevent_macro_expansion() {
+    macrotest::expand("tests/expand/*.rs");
+}
+
+#[test]
+fn test_contractevent_compiles() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/expand/basic.rs");
+    t.pass("tests/expand/generics.rs");
+}


### PR DESCRIPTION
Make a stub for `publish` by changing our implementation of the `contractevent` macro. Credits to codex for helping.

Add some documentation. 