### PR TITLE
chore(deps): bump soroban-sdk 25.1.1 -> 26.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ quote = "1"
 syn = "2"
 macrotest = "1"
 trybuild = "1"
-soroban-sdk = "25.1.1"
+soroban-sdk = "26.1.0"
 
 
 


### PR DESCRIPTION
## Summary

Bumps the workspace `soroban-sdk` dependency from `25.1.1` to `26.1.0`.

```diff
-soroban-sdk = "25.1.1"
+soroban-sdk = "26.1.0"
```

`soroban-sdk` 26.x is the current SDK line; 26.0 → 26.1 carries no breaking changes for the surface `cvlr-soroban`/`-macros`/`-derive` use. Projects already on `soroban-sdk` 26.1 (for us, the upgrade required by OpenZeppelin `stellar-*` 0.7.2) currently cannot consume `cvlr-soroban` pinned at 25.1.1 without a vendor patch.

## Motivation

The [XOXNO rs-lending-xlm](https://github.com/XOXNO/rs-lending-xlm) Stellar lending protocol uses CVLR for formal verification. We moved the workspace to `soroban-sdk` 26.1.0 and currently **vendor `cvlr-soroban` with this single version bump** to keep the Certora harness building. Upstreaming it removes the need for the vendor.

## Test plan

- [x] Our Certora harness compiles against `cvlr-soroban` on `soroban-sdk` 26.1.0.
- [ ] Maintainer confirms `cvlr-soroban` builds/tests on 26.1.0 in upstream CI.

Opening as **draft** for maintainer feedback.
